### PR TITLE
Adding gradle dependency to fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
     mavenCentral()
     maven { url "https://jitpack.io" }
     maven { url "https://repo.spring.io/plugins-release/" }
+    maven { url "https://repo.jenkins-ci.org/releases/" }
 }
 
 dependencies {


### PR DESCRIPTION
Ysoserial has a dependency on org.jenkins-ci.main:remoting:2.55. An additional maven url was added to allow the build to complete.

#### Details

```
$ ./gradlew shadowJar

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':shadowJar'.
> Could not resolve all dependencies for configuration ':runtimeClasspath'.
   > Could not find org.jenkins-ci.main:remoting:2.55.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/jenkins-ci/main/remoting/2.55/remoting-2.55.pom
       - https://repo.maven.apache.org/maven2/org/jenkins-ci/main/remoting/2.55/remoting-2.55.jar
       - https://jitpack.io/org/jenkins-ci/main/remoting/2.55/remoting-2.55.pom
       - https://jitpack.io/org/jenkins-ci/main/remoting/2.55/remoting-2.55.jar
       - https://repo.spring.io/plugins-release/org/jenkins-ci/main/remoting/2.55/remoting-2.55.pom
       - https://repo.spring.io/plugins-release/org/jenkins-ci/main/remoting/2.55/remoting-2.55.jar
     Required by:
         project : > com.github.frohoff:ysoserial:master-SNAPSHOT:6eca5bc740-1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s

```