### PR TITLE
Depend on concrete version of ysoserial to fix #17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     compile group: 'org.javassist', name: 'javassist', version: '3.27.0-GA'
     compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
 
-    implementation 'com.github.frohoff:ysoserial:master-SNAPSHOT'
+    implementation 'com.github.frohoff:ysoserial:0.0.6'
     implementation 'com.github.BishopFox:GadgetProbe:master-SNAPSHOT'
 }


### PR DESCRIPTION
Change to concrete version of ysoserial, as master-SNAPSHOT fails.